### PR TITLE
 implemented All tax types API

### DIFF
--- a/src/controllers/paymentsController.js
+++ b/src/controllers/paymentsController.js
@@ -1,10 +1,49 @@
+/* eslint-disable no-console */
 /* eslint-disable no-unused-vars */
 /* eslint-disable func-names */
 const User = require('../models/Users');
 const Gateway = require('../models/Gateway');
 const Payments = require('../models/Payments');
 
-exports.paymentTypes = function (req, res) {
+//  calls the getTaxTypes methods
+exports.getTaxTypes = function (req, res) {
+  const payments = Payments.getOtherTaxTypes();
+  payments.then((types) => {
+    if (types === undefined || types.length === 0) {
+      // array empty or does not exist
+      res.status(400).json({
+        status: true,
+        data: ' No TaxType returned'
+      });
+    } else {
+      res.status(200).json({
+        status: true,
+        data: types
+      });
+    }
+  }).catch((err) => {
+    res.status(400).json({
+      status: false,
+      data: err
+    });
+  });
+};
+
+// calls the addTaxTypes methods
+exports.addTaxTypes = function (req, res) {
+  const taxType = req.body;
+  const payments = new Payments();
+  payments.addOtherTaxTypes(taxType).then(() => {
+    res.status(200).json({
+      status: true,
+      data: 'Successfully added!'
+    });
+  }).catch((err) => {
+    res.status(400).json({
+      status: false,
+      data: err
+    });
+  });
 };
 
 //  get payment history from taxPayerID
@@ -14,7 +53,7 @@ exports.paymentHistory = function (req, res) {
   payments.getHistory().then((data) => {
     if (data === undefined || data.length === 0) {
       // array empty or does not exist
-      res.status(500).json({
+      res.status(404).json({
         status: false,
         data: ' Invalid Tax Payer ID'
       });
@@ -25,7 +64,7 @@ exports.paymentHistory = function (req, res) {
       });
     }
   }).catch((err) => {
-    res.status(500).json({
+    res.status(400).json({
       status: false,
       data: err
     });
@@ -33,5 +72,7 @@ exports.paymentHistory = function (req, res) {
 };
 
 exports.paymentReceipt = function (req, res) {
+  return new Promise((resolve, reject) => {
 
+  });
 };

--- a/src/models/Payments.js
+++ b/src/models/Payments.js
@@ -4,7 +4,6 @@
 /* eslint-disable max-len */
 /* eslint-disable func-names */
 /* eslint-disable no-unused-vars */
-const validator = require('validator');
 
 const usersCollection = require('../db').db().collection('users');
 
@@ -41,8 +40,6 @@ Payments.addToHistory = function (refData, taxPayerId) {
       }).catch((err) => {
         reject(err);
       });
-    }).catch((err) => {
-
     });
   });
 };

--- a/src/models/Payments.js
+++ b/src/models/Payments.js
@@ -4,16 +4,24 @@
 /* eslint-disable max-len */
 /* eslint-disable func-names */
 /* eslint-disable no-unused-vars */
+const validator = require('validator');
+
 const usersCollection = require('../db').db().collection('users');
 
 const paymentsCollection = require('../db').db().collection('payments');
+
+const taxTypesCollection = require('../db').db().collection('taxtypes');
 
 const Payments = function (taxPayerID) {
   this.taxPayerID = taxPayerID;
   if (this.taxPayerID == null) {
     this.taxPayerID = false;
   }
+  this.errors = [];
+  this.taxType = null;
 };
+
+
 Payments.addToHistory = function (refData, taxPayerId) {
   return new Promise((resolve, reject) => {
     const selectedData = {
@@ -51,6 +59,50 @@ Payments.prototype.getHistory = function () {
     }).catch((err) => {
       reject('err');
     });
+  });
+};
+
+
+// get all other tax types asides the PIT tax
+Payments.getOtherTaxTypes = function () {
+  return new Promise((resolve, reject) => {
+    taxTypesCollection.find({}).toArray().then((docs) => {
+      const taxTypes = docs.map((doc) => doc);
+      resolve(taxTypes);
+    }).catch((err) => {
+      reject(err);
+    });
+  });
+};
+
+Payments.prototype.validate = function () {
+  return new Promise(async (resolve, reject) => {
+    this.taxType = {
+      name: this.taxType.name.trim().toLowerCase(),
+      type: this.taxType.type.trim().toUpperCase()
+    };
+    const taxNameExists = await taxTypesCollection
+      .findOne({ name: this.taxType.name });
+    if (taxNameExists) {
+      this.errors.push('This Tax name already exit.');
+    }
+    resolve();
+  });
+};
+// Add other tax types asides the PIT tax
+Payments.prototype.addOtherTaxTypes = async function (type) {
+  this.taxType = type;
+  await this.validate();
+
+  return new Promise(async (resolve, reject) => {
+    // if no errors
+    if (!this.errors.length) {
+      // upload to taxtypes colletion
+      await taxTypesCollection.insertOne(this.taxType);
+      resolve();
+    } else {
+      reject(this.errors);
+    }
   });
 };
 

--- a/src/routes/payments.js
+++ b/src/routes/payments.js
@@ -7,7 +7,8 @@ const usersController = require('../controllers/usersController');
 router.use(cors());
 
 
-router.get('/types', paymentsController.paymentTypes);
+router.get('/tax_types', usersController.mustBeLoggedIn, paymentsController.getTaxTypes);
+router.post('/tax_types', usersController.mustBeLoggedIn, paymentsController.addTaxTypes);
 router.get('/history/:taxPayerID', usersController.mustBeLoggedIn, paymentsController.paymentHistory);
 router.get('/receipt/:taxPayerID', paymentsController.paymentReceipt);
 


### PR DESCRIPTION
 API routes for All tax types .
GET: return a list of tax types allowed on the application. We're focusing on all types of internal revenues.
POST: Add tax types .

fixes #21 