### PR TITLE
User pit

### DIFF
--- a/src/controllers/paymentsController.js
+++ b/src/controllers/paymentsController.js
@@ -1,3 +1,4 @@
+/* eslint-disable linebreak-style */
 /* eslint-disable no-console */
 /* eslint-disable no-unused-vars */
 /* eslint-disable func-names */

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -6,12 +6,11 @@ const jwt = require('jsonwebtoken');
 const { check, validationResult } = require('express-validator');
 const bcrypt = require('bcryptjs');
 const sgMail = require('@sendgrid/mail');
-const config = require('../config/auth.config');
 const User = require('../models/Users');
 const usersCollection = require('../db').db('paytax').collection('users');
 
 exports.home = (req, res) => {
-// return payer Id by email
+  // return payer Id by email
   res.json('testing api');
 };
 
@@ -109,7 +108,7 @@ exports.recovery = [
       });
     }
     // create recovery token
-    const token = jwt.sign({ id: user.id }, config.secret, {
+    const token = jwt.sign({ id: user.taxPayerId }, process.env.JWTSECRET, {
       expiresIn: 7200 // 2 hours
     });
 
@@ -125,13 +124,13 @@ exports.recovery = [
         
         We received a request to use PayTax APP Account Recovery to regain access to your account. To continue, click this link:
         
-        <a href="https://paytaxapp.com/${token}"> Start LastPass Account Recovery </a>
+        <a href="${process.env.RECOVERY}${token}"> Start LastPass Account Recovery </a>
         
         The link expires in 2 hours.
         
         If the link doesn't work, visit this site by copying this address to your browser:
         
-        https://paytaxapp.com/${token} </pre>
+        ${process.env.RECOVERY}${token} </pre>
       `
     };
     sgMail.send(msg);
@@ -139,6 +138,70 @@ exports.recovery = [
       status: true,
       data: 'Message sent'
     });
+  }
+];
+
+exports.recoverPassword = [
+  [
+    // password must be at least 8 chars long
+    check('password').isLength({ min: 8 }).withMessage('Password must be at least 8 chars long'),
+    check('confirmPassword').isLength({ min: 8 }).withMessage('Password confirmation must be at least 8 chars long')
+  ], async (req, res) => {
+    // Finds the validation errors in this request and wraps them in an object with handy functions
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(422).json({ status: false, errors: errors.array() });
+    }
+
+    try {
+      const { password } = req.body;
+      const { confirmPassword } = req.body;
+      if (password !== confirmPassword) return res.status(422).json({ status: false, data: 'Passwords do not match' });
+      const salt = bcrypt.genSaltSync(10);
+      const passwordHash = bcrypt.hashSync(password, salt);
+      // get access token
+      const { token } = req.query;
+      if (!token) {
+        return res.status(403).json({
+          status: false,
+          data: 'Sorry, you must provide a valid token.'
+        });
+      }
+      req.apiUser = jwt.verify(token, process.env.JWTSECRET);
+      const user = await usersCollection.findOneAndUpdate({ taxPayerId: req.apiUser.id },
+        { $set: { password: passwordHash } });
+      if (!user) {
+        return res.status(400).json({
+          status: false,
+          data: 'User not found'
+        });
+      }
+      // send success mail
+      sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+      const msg = {
+        to: `${user.value.email}`,
+        from: 'contact@app.paytax.com',
+        subject: 'PayTax APP Password Reset',
+        text: 'Pay your tax anywhere with app.paytax.com',
+        html: `
+        <h1> PayTax account recovery request </h1>
+        Hello ${user.value.businessName}, <br/>
+        
+        <p> Your password has been reset successfully! </p>
+      `
+      };
+      sgMail.send(msg);
+
+      return res.status(200).json({
+        status: true,
+        data: 'Password reset was successful'
+      });
+    } catch (error) {
+      return res.status(400).json({
+        status: false,
+        data: `Sorry, an error occured - ${error}`
+      });
+    }
   }
 ];
 

--- a/src/controllers/usersController.js
+++ b/src/controllers/usersController.js
@@ -4,6 +4,7 @@
 const jwt = require('jsonwebtoken');
 const { check, validationResult } = require('express-validator');
 const bcrypt = require('bcryptjs');
+const sgMail = require('@sendgrid/mail');
 const config = require('../config/auth.config');
 const User = require('../models/Users');
 const usersCollection = require('../db').db('paytax').collection('users');
@@ -40,7 +41,7 @@ exports.login = [
     }
     const user = await usersCollection.findOne({
       taxPayerId: req.body.taxPayerId
-    });
+    }, { password: 0, _id: 0 });
     if (!user) {
       return res.status(400).json({
         status: false,
@@ -72,9 +73,60 @@ exports.mustBeLoggedIn = (req, res, next) => {
   next();
 };
 
-exports.recovery = (req, res) => {
-  res.json('recovery in progress');
-};
+exports.recovery = [
+  [
+    // taxPayerId must be alphanumeric and at least 15 characters long
+    check('taxPayerId').isAlphanumeric().withMessage('Payer ID must be alphanumeric')
+      .isLength({ min: 10, max: 10 })
+      .withMessage('Tax Payer ID must be 10 chars long')
+  ], async (req, res) => {
+    // Finds the validation errors in this request and wraps them in an object with handy functions
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(422).json({ status: false, errors: errors.array() });
+    }
+    const user = await usersCollection.findOne({
+      taxPayerId: req.body.taxPayerId
+    });
+    if (!user) {
+      return res.status(400).json({
+        status: false,
+        data: 'User not found'
+      });
+    }
+    // create recovery token
+    const token = jwt.sign({ id: user.id }, config.secret, {
+      expiresIn: 7200 // 2 hours
+    });
+
+    sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+    const msg = {
+      to: `${user.email}`,
+      from: 'contact@app.paytax.com',
+      subject: 'PayTax APP Account Recovery',
+      text: 'Pay your tax anywhere with app.paytax.com',
+      html: `
+        <pre><h1> PayTax account recovery request </h1>
+        Hello ${user.businessName},
+        
+        We received a request to use PayTax APP Account Recovery to regain access to your account. To continue, click this link:
+        
+        <a href="https://paytaxapp.com/${token}"> Start LastPass Account Recovery </a>
+        
+        The link expires in 2 hours.
+        
+        If the link doesn't work, visit this site by copying this address to your browser:
+        
+        https://paytaxapp.com/${token} </pre>
+      `
+    };
+    sgMail.send(msg);
+    return res.status(200).json({
+      status: true,
+      data: 'Message sent'
+    });
+  }
+];
 
 exports.getUserData = [
   [

--- a/src/models/Gateway.js
+++ b/src/models/Gateway.js
@@ -1,3 +1,4 @@
+/* eslint-disable linebreak-style */
 /* eslint-disable no-async-promise-executor */
 /* eslint-disable no-console */
 /* eslint-disable func-names */

--- a/src/models/Payments.js
+++ b/src/models/Payments.js
@@ -1,3 +1,4 @@
+/* eslint-disable linebreak-style */
 /* eslint-disable prefer-promise-reject-errors */
 /* eslint-disable no-async-promise-executor */
 /* eslint-disable no-console */

--- a/src/models/Users.js
+++ b/src/models/Users.js
@@ -12,7 +12,7 @@ const sgMail = require('@sendgrid/mail');
 
 sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 
-const usersCollection = require('../db').db().collection('users');
+const usersCollection = require('../db').db('paytax').collection('users');
 
 const User = function (data) {
   this.data = data;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -10,6 +10,7 @@ router.use(cors());
 router.post('/register', usersController.registeration); // sent taxId as email
 router.post('/login', usersController.login);
 router.post('/recovery', usersController.recovery);
+router.post('/change-password', usersController.recoverPassword);
 router.get('/:taxID', usersController.mustBeLoggedIn, usersController.getUserData);
 
 


### PR DESCRIPTION
## Description
Password recovery request. 

Email user an url to reset password, and another mail if recovery was successful.

POST: https://paytax-app.herokuapp.com/api/v1/recovery/
accepts taxpayerID as request body. 

POST: https://paytax-app.herokuapp.com/api/v1/change-password/
accepts token (this is attached in the url sent to the user for password recovery request) as query parameter and password and confirmPassword as request body. 

Fixes #12

## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [x] New and existing unit tests pass locally with my changes
